### PR TITLE
robustification de la recherche par prefixe sur les termes

### DIFF
--- a/ginco-webservices/src/main/java/fr/mcc/ginco/soap/SOAPThesaurusTermServiceImpl.java
+++ b/ginco-webservices/src/main/java/fr/mcc/ginco/soap/SOAPThesaurusTermServiceImpl.java
@@ -142,7 +142,7 @@ public class SOAPThesaurusTermServiceImpl implements ISOAPThesaurusTermService {
 	                                                                         int startIndex, int limit) {
 		if (StringUtils.isNotEmpty(request) && limit != 0) {
 			try {
-				String requestFormat = SolrField.LEXICALVALUE_STR+":"+request + "*";
+				String requestFormat = "{!prefix f=" + SolrField.LEXICALVALUE_STR+"}"+request;
 				List<ReducedThesaurusTerm> reducedThesaurusTermList = new ArrayList<ReducedThesaurusTerm>();
 				SortCriteria crit = new SortCriteria(null, null);
 				Integer searchType = SearchEntityType.TERM;


### PR DESCRIPTION
La modification de la syntaxe permet notamment d'éviter de créer des requetes solr incorrectes par exemple en cas de saisi d'un espace.