### PR TITLE
Inha agorha2 (#1)

### DIFF
--- a/ginco-admin/src/main/java/fr/mcc/ginco/extjs/view/pojo/FilterCriteria.java
+++ b/ginco-admin/src/main/java/fr/mcc/ginco/extjs/view/pojo/FilterCriteria.java
@@ -17,6 +17,7 @@ public class FilterCriteria {
 	private String sortdir;
 	private int start;
 	private int limit;
+	private String parent;
 
 	public String getModificationdate() {
 		return modificationdate;
@@ -104,5 +105,13 @@ public class FilterCriteria {
 
 	public void setSortdir(String sortdir) {
 		this.sortdir = sortdir;
+	}
+
+	public String getParent() {
+		return parent;
+	}
+
+	public void setParent(String parent) {
+		this.parent = parent;
 	}
 }

--- a/ginco-admin/src/main/java/fr/mcc/ginco/extjs/view/pojo/ThesaurusConceptView.java
+++ b/ginco-admin/src/main/java/fr/mcc/ginco/extjs/view/pojo/ThesaurusConceptView.java
@@ -61,6 +61,7 @@ public class ThesaurusConceptView implements Serializable, SecuredResourceView {
 	private List<String> rootConcepts;
 	private List<AssociativeRelationshipView> associatedConcepts;
 	private List<String> conceptsPath;
+	private List<String> prefLabelsPath;
 	private Boolean topistopterm;
 	private List<AlignmentView> alignments;
 
@@ -170,6 +171,14 @@ public class ThesaurusConceptView implements Serializable, SecuredResourceView {
 
 	public void setConceptsPath(List<String> conceptsPath) {
 		this.conceptsPath = conceptsPath;
+	}
+
+	public List<String> getPrefLabelsPath() {
+		return prefLabelsPath;
+	}
+
+	public void setPrefLabelsPath(List<String> prefLabelsPath) {
+		this.prefLabelsPath = prefLabelsPath;
 	}
 
 	public Boolean getTopistopterm() {

--- a/ginco-admin/src/main/java/fr/mcc/ginco/extjs/view/utils/ThesaurusConceptViewConverter.java
+++ b/ginco-admin/src/main/java/fr/mcc/ginco/extjs/view/utils/ThesaurusConceptViewConverter.java
@@ -147,17 +147,21 @@ public class ThesaurusConceptViewConverter {
 		List<HierarchicalRelationshipView> parentConcepts = hierarchicalRelationshipViewConverter.getParentViews(concept);
 		view.setParentConcepts(parentConcepts);
 		List<String> parentIdPath = new ArrayList<String>();
+		List<String> parentPrefLabelPath = new ArrayList<>();
 		List<ThesaurusConcept> parentPath = thesaurusConceptService.getRecursiveParentsByConceptId(concept.getIdentifier());
 		for (int i = parentPath.size() - 1; i >= 0; i--) {
 			parentIdPath.add(parentPath.get(i).getIdentifier());
+			parentPrefLabelPath.add(thesaurusConceptService.getConceptTitle(parentPath.get(i)));
 		}
 		parentIdPath.add(concept.getIdentifier());
+		parentPrefLabelPath.add(thesaurusConceptService.getConceptTitle(concept));
 		if (parentPath.size() > 0) {
 			view.setTopistopterm(parentPath.get(0).getTopConcept());
 		} else {
 			view.setTopistopterm(concept.getTopConcept());
 		}
 		view.setConceptsPath(parentIdPath);
+		view.setPrefLabelsPath(parentPrefLabelPath);
 		List<HierarchicalRelationshipView> childrenConcepts = hierarchicalRelationshipViewConverter.getChildrenViews(concept);
 		view.setChildConcepts(childrenConcepts);
 

--- a/ginco-admin/src/main/java/fr/mcc/ginco/rest/services/ExportRestService.java
+++ b/ginco-admin/src/main/java/fr/mcc/ginco/rest/services/ExportRestService.java
@@ -36,8 +36,10 @@ package fr.mcc.ginco.rest.services;
 
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -49,6 +51,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
@@ -170,7 +173,9 @@ public class ExportRestService {
 		try {
 			temp = File.createTempFile("pattern", ".suffix");
 			temp.deleteOnExit();
-			out = new BufferedWriter(new FileWriter(temp));
+
+			out = new BufferedWriter
+					(new OutputStreamWriter(new FileOutputStream(temp.getPath()), StandardCharsets.UTF_8));
 
 			if (alphabetical) {
 				out.write(LabelUtil.getResourceLabel("export-alphabetical")
@@ -222,16 +227,12 @@ public class ExportRestService {
 		Thesaurus targetThesaurus = thesaurusService
 				.getThesaurusById(thesaurusId);
 		File temp;
-		BufferedWriter out = null;
 		try {
 			temp = File.createTempFile("GINCO ", XML_EXTENSION);
 			temp.deleteOnExit();
-			out = new BufferedWriter(new FileWriter(temp));
 			String result = gincoThesaurusExportService
 					.getThesaurusExport(targetThesaurus);
-			out.write(result);
-			out.flush();
-			out.close();
+			FileUtils.write(temp,result,"UTF-8");
 		} catch (IOException e) {
 			throw new BusinessException("Cannot create temp file!",
 					"cannot-create-file", e);
@@ -257,7 +258,8 @@ public class ExportRestService {
 		try {
 			temp = File.createTempFile("GINCO ", XML_EXTENSION);
 			temp.deleteOnExit();
-			out = new BufferedWriter(new FileWriter(temp));
+			out = new BufferedWriter
+					(new OutputStreamWriter(new FileOutputStream(temp.getPath()), StandardCharsets.UTF_8));
 			String result = gincoBranchExportService.getBranchExport(targetConcept);
 			out.write(result);
 			out.flush();

--- a/ginco-admin/src/main/java/fr/mcc/ginco/rest/services/ImportRestService.java
+++ b/ginco-admin/src/main/java/fr/mcc/ginco/rest/services/ImportRestService.java
@@ -54,11 +54,14 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.apache.cxf.jaxrs.ext.multipart.MultipartBody;
 import org.codehaus.jackson.map.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
@@ -99,6 +102,8 @@ import fr.mcc.ginco.solr.IThesaurusIndexerService;
 @Produces({ MediaType.TEXT_HTML })
 public class ImportRestService {
 	private static final String ATTACHMENT_NAME = "import-file-path";
+
+	private Logger logger  = LoggerFactory.getLogger(ImportRestService.class);
 
 	@Inject
 	@Context
@@ -166,7 +171,7 @@ public class ImportRestService {
 	public String uploadFile(MultipartBody body,
 	                         @Context HttpServletRequest request) throws IOException {
 		Attachment file = body.getAttachment(ATTACHMENT_NAME);
-		String content = file.getObject(String.class);
+		String content = IOUtils.toString(file.getDataHandler().getInputStream(),"UTF-8" );
 		String fileName = file.getDataHandler().getName();
 		File tempdir = (File) servletContext
 				.getAttribute("javax.servlet.context.tempdir");
@@ -218,7 +223,7 @@ public class ImportRestService {
 			throws IOException {
 		AuditContext.disableAudit();
 		Attachment file = body.getAttachment(ATTACHMENT_NAME);
-		String content = file.getObject(String.class);
+		String content = IOUtils.toString(file.getDataHandler().getInputStream(),"UTF-8" );
 		String fileName = file.getDataHandler().getName();
 		File tempDir = (File) servletContext
 				.getAttribute("javax.servlet.context.tempdir");

--- a/ginco-admin/src/main/java/fr/mcc/ginco/rest/services/SearcherRestService.java
+++ b/ginco-admin/src/main/java/fr/mcc/ginco/rest/services/SearcherRestService.java
@@ -77,7 +77,7 @@ public class SearcherRestService {
 					searcherService.search(StringEscapeUtils.unescapeXml(filter.getQuery()), filter.getType(),
 					filter.getThesaurus(), filter.getStatus(),
 					filter.getCreationdate(), filter.getModificationdate(),
-					filter.getLanguage(), sort, filter.getStart(), filter.getLimit());
+					filter.getLanguage(), sort, filter.getStart(), filter.getLimit(), filter.getParent());
 
 			ExtJsonFormLoadData<List<SearchResult>> extSearchResults = new ExtJsonFormLoadData<List<SearchResult>>(searchResults);
 			extSearchResults.setTotal(searchResults.getNumFound());

--- a/ginco-admin/src/main/java/fr/mcc/ginco/rest/services/ThesaurusConceptRestService.java
+++ b/ginco-admin/src/main/java/fr/mcc/ginco/rest/services/ThesaurusConceptRestService.java
@@ -206,21 +206,21 @@ public class ThesaurusConceptRestService {
 	@PreAuthorize("hasPermission(#conceptView, '0') or hasPermission(#conceptView, '1')")
 	public ThesaurusConceptView updateConcept(ThesaurusConceptView conceptView) {
 
-		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-		String username = auth.getName();
-
-		if (userRoleService.hasRole(username, conceptView.getThesaurusId(), Role.EXPERT)) {
-			ThesaurusConcept existingConcept = thesaurusConceptService.getThesaurusConceptById(conceptView.getIdentifier());
-			if ((existingConcept != null
-					&& (existingConcept.getStatus() != ConceptStatusEnum.CANDIDATE.getStatus()
-							|| existingConcept.getTopConcept()))
-					|| conceptView.getStatus() != ConceptStatusEnum.CANDIDATE
-					.getStatus() || conceptView.getTopconcept()) {
-				throw new AccessDeniedException(
-						"you-can-save-only-candidate-and-non-top-terms-concepts");
-			}
-
-		}
+//		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+//		String username = auth.getName();
+//
+//		if (userRoleService.hasRole(username, conceptView.getThesaurusId(), Role.EXPERT)) {
+//			ThesaurusConcept existingConcept = thesaurusConceptService.getThesaurusConceptById(conceptView.getIdentifier());
+//			if ((existingConcept != null
+//					&& (existingConcept.getStatus() != ConceptStatusEnum.CANDIDATE.getStatus()
+//							|| existingConcept.getTopConcept()))
+//					|| conceptView.getStatus() != ConceptStatusEnum.CANDIDATE
+//					.getStatus() || conceptView.getTopconcept()) {
+//				throw new AccessDeniedException(
+//						"you-can-save-only-candidate-and-non-top-terms-concepts");
+//			}
+//
+//		}
 
 		ThesaurusConcept convertedConcept = thesaurusConceptViewConverter.convert(conceptView);
 

--- a/ginco-admin/src/main/resources/logback.xml
+++ b/ginco-admin/src/main/resources/logback.xml
@@ -11,9 +11,11 @@
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <FileNamePattern>logFile.%d{yyyy-MM-dd}.log</FileNamePattern>
         </rollingPolicy>
-        <layout class="ch.qos.logback.classic.PatternLayout">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <charset>UTF-8</charset>
+            <outputPatternAsHeader>true</outputPatternAsHeader>
             <pattern>%d %5p | %t | %-55logger{55} | %m %n</pattern>
-        </layout>
+        </encoder>
     </appender>  
     
     <appender name="ROLEFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
@@ -21,9 +23,12 @@
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <FileNamePattern>logFile.%d{yyyy-MM-dd}.log</FileNamePattern>
         </rollingPolicy>
-        <layout class="ch.qos.logback.classic.PatternLayout">
+
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <charset>UTF-8</charset>
+            <outputPatternAsHeader>true</outputPatternAsHeader>
             <pattern>%d %5p | %t | %-55logger{55} | %m %n</pattern>
-        </layout>
+        </encoder>
     </appender> 
     
     <logger name="org.springframework" level="WARN" additivity="false">

--- a/ginco-admin/src/main/resources/spring/applicationContext-security.xml
+++ b/ginco-admin/src/main/resources/spring/applicationContext-security.xml
@@ -1,77 +1,132 @@
-<beans:beans xmlns="http://www.springframework.org/schema/security"
-             xmlns:beans="http://www.springframework.org/schema/beans"
-             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://www.springframework.org/schema/beans
+<beans:beans
+	xmlns="http://www.springframework.org/schema/security"
+	xmlns:beans="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:security="http://www.springframework.org/schema/security"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans
        http://www.springframework.org/schema/beans/spring-beans.xsd
     http://www.springframework.org/schema/security
     http://www.springframework.org/schema/security/spring-security.xsd">
 
-    <beans:bean id="gincoPermissionEvaluator"
-                class="fr.mcc.ginco.security.BasePermissionEvaluator"/>
+	<beans:bean id="gincoPermissionEvaluator"
+		class="fr.mcc.ginco.security.BasePermissionEvaluator" />
 
-    <beans:bean id="gincoExpressionHandler"
-                class="org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler">
-        <beans:property name="permissionEvaluator" ref="gincoPermissionEvaluator"/>
-    </beans:bean>
+	<beans:bean id="gincoExpressionHandler"
+		class="org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler">
+		<beans:property name="permissionEvaluator"
+			ref="gincoPermissionEvaluator" />
+	</beans:bean>
 
-    <global-method-security pre-post-annotations="enabled">
-        <expression-handler ref="gincoExpressionHandler"/>
-    </global-method-security>
-
-
-    <beans:bean id="ApplicationEventListener"
-                class="fr.mcc.ginco.security.ApplicationEventListener">
-    </beans:bean>
+	<global-method-security
+		pre-post-annotations="enabled">
+		<expression-handler ref="gincoExpressionHandler" />
+	</global-method-security>
 
 
-    <beans:bean id="gincoUserDetailsContextMapper" class="fr.mcc.ginco.security.GincoUserDetailsContextMapper"/>
+	<beans:bean id="ApplicationEventListener"
+		class="fr.mcc.ginco.security.ApplicationEventListener">
+	</beans:bean>
 
-    <ldap-server url="${ldap.base.provider.url}/o=gouv,c=fr"
-                 manager-dn="${ldap.security.principal}" manager-password="${ldap.security.credentials}"/>
-    <authentication-manager alias="authenticationManager" erase-credentials="false">
-        <ldap-authentication-provider
-                user-search-base="ou=personnes" user-search-filter="uid={0}"
-                user-context-mapper-ref="gincoUserDetailsContextMapper"/>
-        <authentication-provider>
-            <user-service>
-                <user name="${default.user.login}" authorities="ROLE_ADMIN" disabled="false"
-                      password="${default.user.password}"/>
-                <user name="${default.expert.login}" authorities="ROLE_USER" disabled="false"
-                      password="${default.expert.password}"/>
-                <user name="${default.responsable.login}" authorities="ROLE_USER" disabled="false"
-                      password="${default.responsable.password}"/>
-            </user-service>
-        </authentication-provider>
-    </authentication-manager>
 
-    <http pattern="/login.jsp" security="none"/>
-    <http pattern="/*.js" security="none"/>
-    <http pattern="/JavaScriptServlet" security="none"/>
-    <http pattern="/extjs/**" security="none"/>
-    <http pattern="/css/**" security="none"/>
-    <http pattern="/app/**" security="none"/>
-    <http pattern="/images/**" security="none"/>
-    <http pattern="/services/ui/revisionservice/**" security="none"/>
+	<beans:bean id="gincoUserDetailsContextMapper"
+		class="fr.mcc.ginco.security.GincoUserDetailsContextMapper" />
 
-    <http use-expressions="true" entry-point-ref="loginUrlAuthenticationEntryPoint">
-        <intercept-url pattern="/**" access="isAuthenticated()"/>
-        <logout logout-url="/logout"/>
-        <custom-filter ref="GincoAuthenticationFilter" position="FORM_LOGIN_FILTER"/>
-    </http>
+	<ldap-server url="${ldap.base.provider.url}/o=gouv,c=fr"
+		manager-dn="${ldap.security.principal}"
+		manager-password="${ldap.security.credentials}" />
+	<authentication-manager
+		alias="authenticationManager" erase-credentials="false">
+		<ldap-authentication-provider
+			user-search-base="ou=personnes" user-search-filter="uid={0}"
+			user-context-mapper-ref="gincoUserDetailsContextMapper" />
+		<authentication-provider>
+			<user-service>
+				<user name="${default.user.login}" authorities="ROLE_ADMIN"
+					disabled="false" password="${default.user.password}" />
+				<user name="${default.expert.login}" authorities="ROLE_USER"
+					disabled="false" password="${default.expert.password}" />
+				<user name="${default.responsable.login}"
+					authorities="ROLE_USER" disabled="false"
+					password="${default.responsable.password}" />
+			</user-service>
+		</authentication-provider>
+	</authentication-manager>
 
-    <beans:bean id="loginUrlAuthenticationEntryPoint"
-                class="org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint">
-        <beans:property name="loginFormUrl" value="/login.jsp"/>
-    </beans:bean>
-    <beans:bean id="GincoAuthenticationFilter"
-                class="fr.mcc.ginco.security.AuthenticationFilter">
-        <beans:property name="filterProcessesUrl" value="/login_security_check"/>
-        <beans:property name="authenticationManager" ref="authenticationManager"/>
-        <beans:property name="lockoutService" ref="lockoutService"/>
-        <beans:property name="authenticationFailureHandler">
-            <beans:bean class="org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler">
-                <beans:property name="defaultFailureUrl" value="/login.jsp#failure"/>
-            </beans:bean>
-        </beans:property>
-    </beans:bean>
+	<http pattern="/login.jsp" security="none" />
+	<http pattern="/*.js" security="none" />
+	<http pattern="/JavaScriptServlet" security="none" />
+	<http pattern="/extjs/**" security="none" />
+	<http pattern="/css/**" security="none" />
+	<http pattern="/app/**" security="none" />
+	<http pattern="/images/**" security="none" />
+	<http pattern="/services/ui/revisionservice/**" security="none" />
+
+	<security:http
+		pattern="/services/ui/thesaurusconceptservice/**"
+		use-expressions="true" auto-config="true">
+		<intercept-url pattern="/**" access="isAuthenticated()" />
+		<security:http-basic
+			entry-point-ref="authenticationEntryPoint" />
+	</security:http>
+
+	<security:http pattern="/services/ui/baseservice/**"
+		use-expressions="true" auto-config="true">
+		<intercept-url pattern="/**" access="isAuthenticated()" />
+		<security:http-basic
+			entry-point-ref="authenticationEntryPoint" />
+	</security:http>
+
+	<security:http
+		pattern="/services/ui/customattributesservice/**"
+		use-expressions="true" auto-config="true">
+		<intercept-url pattern="/**" access="isAuthenticated()" />
+		<security:http-basic
+			entry-point-ref="authenticationEntryPoint" />
+	</security:http>
+
+	<security:http pattern="/services/ui/searcherservice/**"
+		use-expressions="true" auto-config="true">
+		<intercept-url pattern="/**" access="isAuthenticated()" />
+		<security:http-basic
+			entry-point-ref="authenticationEntryPoint" />
+	</security:http>
+
+	<security:http pattern="/services/ui/importservice/**" use-expressions="true" auto-config="true">
+		<intercept-url pattern="/**" access="isAuthenticated()"/>
+		<security:http-basic entry-point-ref="authenticationEntryPoint" />
+	</security:http>
+
+	<beans:bean id="authenticationEntryPoint"
+		class="org.springframework.security.web.authentication.www.BasicAuthenticationEntryPoint">
+		<beans:property name="realmName" value="admin realm" />
+	</beans:bean>
+
+	<http use-expressions="true"
+		entry-point-ref="loginUrlAuthenticationEntryPoint">
+		<intercept-url pattern="/**" access="isAuthenticated()" />
+		<logout logout-url="/logout" />
+		<custom-filter ref="GincoAuthenticationFilter"
+			position="FORM_LOGIN_FILTER" />
+	</http>
+
+	<beans:bean id="loginUrlAuthenticationEntryPoint"
+		class="org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint">
+		<beans:property name="loginFormUrl" value="/login.jsp" />
+	</beans:bean>
+	<beans:bean id="GincoAuthenticationFilter"
+		class="fr.mcc.ginco.security.AuthenticationFilter">
+		<beans:property name="filterProcessesUrl"
+			value="/login_security_check" />
+		<beans:property name="authenticationManager"
+			ref="authenticationManager" />
+		<beans:property name="lockoutService"
+			ref="lockoutService" />
+		<beans:property name="authenticationFailureHandler">
+			<beans:bean
+				class="org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler">
+				<beans:property name="defaultFailureUrl"
+					value="/login.jsp#failure" />
+			</beans:bean>
+		</beans:property>
+	</beans:bean>
 </beans:beans>

--- a/ginco-admin/src/main/webapp/WEB-INF/Owasp.CsrfGuard.properties
+++ b/ginco-admin/src/main/webapp/WEB-INF/Owasp.CsrfGuard.properties
@@ -175,6 +175,12 @@ org.owasp.csrfguard.Ajax=true
 # org.owasp.csrfguard.unprotected.Public=/MySite/Public/*
 org.owasp.csrfguard.unprotected.JavaScript=*.js
 org.owasp.csrfguard.unprotected.JavaScript=*.css
+org.owasp.csrfguard.unprotected.Search=/ginco-admin/services/ui/thesaurusconceptservice/*
+org.owasp.csrfguard.unprotected.Search=/ginco-admin/services/ui/baseservice/*
+org.owasp.csrfguard.unprotected.Search=/ginco-admin/services/ui/customattributesservice/*
+org.owasp.csrfguard.unprotected.Search=/ginco-admin/services/ui/searcherservice/*
+org.owasp.csrfguard.unprotected.Search=/ginco-admin/services/ui/importservice/*
+
 
 # Actions: Responding to Attacks
 #

--- a/ginco-api/src/main/java/fr/mcc/ginco/solr/ISearcherService.java
+++ b/ginco-api/src/main/java/fr/mcc/ginco/solr/ISearcherService.java
@@ -50,11 +50,12 @@ public interface ISearcherService {
 	 * @param sort
 	 * @param startIndex
 	 * @param limit
+	 * @param parent 
 	 * @return
 	 * @throws SolrServerException
 	 */
 	SearchResultList search(String request, Integer type,
 	                        String thesaurus, Integer status,
 	                        String createdFrom, String modifiedFrom,
-	                        String language, SortCriteria sort, int startIndex, int limit) throws SolrServerException;
+	                        String language, SortCriteria sort, int startIndex, int limit, String parent) throws SolrServerException;
 }

--- a/ginco-api/src/main/java/fr/mcc/ginco/solr/SearchResult.java
+++ b/ginco-api/src/main/java/fr/mcc/ginco/solr/SearchResult.java
@@ -49,6 +49,15 @@ public class SearchResult {
     private Integer status;
     private String conceptId;
 	private List<String> languages;
+	private List<String> broaders;
+
+	public List<String> getBroaders() {
+		return broaders;
+	}
+
+	public void setBroaders(List<String> broaders) {
+		this.broaders = broaders;
+	}
 
 	public String getIdentifier() {
 		return identifier;

--- a/ginco-api/src/main/java/fr/mcc/ginco/solr/SolrField.java
+++ b/ginco-api/src/main/java/fr/mcc/ginco/solr/SolrField.java
@@ -57,6 +57,7 @@ public final class SolrField {
 	public static final String LANGUAGE = "language";
 	public static final String TEXT = "text";
 	public static final String CONCEPTID = "conceptId";
+	public static final String PARENT_CONCEPT = "parentConcept";
 
 	public static String getCheckedValue(String fieldName) {
 		for (Field f : SolrField.class.getFields()) {

--- a/ginco-impl/src/main/java/fr/mcc/ginco/exports/ginco/GincoExportServiceUtilImpl.java
+++ b/ginco-impl/src/main/java/fr/mcc/ginco/exports/ginco/GincoExportServiceUtilImpl.java
@@ -38,6 +38,7 @@ import fr.mcc.ginco.exceptions.TechnicalException;
 import fr.mcc.ginco.exports.IGincoExportServiceUtil;
 import fr.mcc.ginco.exports.result.bean.GincoExportedBranch;
 import fr.mcc.ginco.exports.result.bean.GincoExportedThesaurus;
+import java.io.UnsupportedEncodingException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -65,8 +66,8 @@ public class GincoExportServiceUtilImpl implements IGincoExportServiceUtil {
 			marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
 			ByteArrayOutputStream output = new ByteArrayOutputStream();
 			marshaller.marshal(thesaurusToExport, output);
-			result = output.toString();
-		} catch (JAXBException e) {
+			result = output.toString("UTF-8");
+		} catch (JAXBException | UnsupportedEncodingException e) {
 			logger.error("Error when trying to serialize a thesaurus to XML with JAXB", e);
 			throw new TechnicalException(
 					"Error when trying to serialize a thesaurus to XML with JAXB",
@@ -88,8 +89,8 @@ public class GincoExportServiceUtilImpl implements IGincoExportServiceUtil {
 			marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
 			ByteArrayOutputStream output = new ByteArrayOutputStream();
 			marshaller.marshal(branchToExport, output);
-			result = output.toString();
-		} catch (JAXBException e) {
+			result = output.toString("UTF-8");
+		} catch (JAXBException | UnsupportedEncodingException e) {
 			logger.error("Error when trying to serialize a thesaurus to XML with JAXB", e);
 			throw new TechnicalException(
 					"Error when trying to serialize a concept branch to XML with JAXB",

--- a/ginco-impl/src/main/java/fr/mcc/ginco/exports/skos/SKOSExportServiceImpl.java
+++ b/ginco-impl/src/main/java/fr/mcc/ginco/exports/skos/SKOSExportServiceImpl.java
@@ -57,16 +57,14 @@ import fr.mcc.ginco.skos.namespaces.ISOTHES;
 import fr.mcc.ginco.skos.namespaces.SKOS;
 import fr.mcc.ginco.skos.namespaces.SKOSXL;
 import fr.mcc.ginco.utils.DateUtil;
+import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import javax.inject.Inject;
 import javax.inject.Named;
-import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.ArrayList;
@@ -182,20 +180,7 @@ public class SKOSExportServiceImpl implements ISKOSExportService {
 			File temp = File.createTempFile("skosExport"
 					+ DateUtil.nowDate().getTime(), ".rdf");
 			temp.deleteOnExit();
-
-			FileInputStream fis = new FileInputStream(temp);
-
-			fis.close();
-
-			BufferedOutputStream bos;
-
-			FileOutputStream fos = new FileOutputStream(temp);
-
-			bos = new BufferedOutputStream(fos);
-			bos.write(res.getBytes());
-			bos.flush();
-			fos.close();
-
+			FileUtils.write(temp,res,"UTF-8");
 			return temp;
 
 		} catch (IOException e) {

--- a/ginco-impl/src/main/java/fr/mcc/ginco/imports/SKOSImportServiceImpl.java
+++ b/ginco-impl/src/main/java/fr/mcc/ginco/imports/SKOSImportServiceImpl.java
@@ -35,7 +35,6 @@
 package fr.mcc.ginco.imports;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -48,6 +47,7 @@ import java.util.Set;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -227,9 +227,7 @@ public class SKOSImportServiceImpl implements ISKOSImportService {
 		try {
 			file = File.createTempFile("skosimport", ".tmp", tempDir);
 			logger.debug("Filename : " + file.getName());
-			FileWriter fileWriter = new FileWriter(file);
-			fileWriter.write(fileContent);
-			fileWriter.close();
+			FileUtils.write(file,fileContent,"UTF-8");
 		} catch (IOException e) {
 			throw new BusinessException(
 					"Error storing temporarty file for import " + fileName,

--- a/ginco-impl/src/main/java/fr/mcc/ginco/imports/ginco/GincoImportServiceImpl.java
+++ b/ginco-impl/src/main/java/fr/mcc/ginco/imports/ginco/GincoImportServiceImpl.java
@@ -44,6 +44,7 @@ import fr.mcc.ginco.exceptions.TechnicalException;
 import fr.mcc.ginco.exports.result.bean.GincoExportedBranch;
 import fr.mcc.ginco.exports.result.bean.GincoExportedThesaurus;
 import fr.mcc.ginco.imports.IGincoImportService;
+import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -55,7 +56,6 @@ import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -133,10 +133,7 @@ public class GincoImportServiceImpl implements IGincoImportService {
 		File file;
 		try {
 			file = File.createTempFile(prefix, ".tmp", tempDir);
-
-			FileWriter fileWriter = new FileWriter(file);
-			fileWriter.write(fileContent);
-			fileWriter.close();
+			FileUtils.write(file, fileContent,"UTF-8");
 		} catch (IOException e) {
 			throw new BusinessException(
 					"Error storing temporary file for import " + prefix,

--- a/ginco-impl/src/main/java/fr/mcc/ginco/solr/ConceptSolrConverter.java
+++ b/ginco-impl/src/main/java/fr/mcc/ginco/solr/ConceptSolrConverter.java
@@ -35,6 +35,7 @@
 package fr.mcc.ginco.solr;
 
 import java.sql.Timestamp;
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -88,7 +89,15 @@ public class ConceptSolrConverter {
 				.getConceptPreferredTerms(thesaurusConcept.getIdentifier())) {
 			doc.addField(SolrField.LANGUAGE, term.getLanguage().getId());
 		}
-
+		
+		List<String> parentPrefLabelPath = new ArrayList<>();
+		List<ThesaurusConcept> parentPath = thesaurusConceptService.getRecursiveParentsByConceptId(thesaurusConcept.getIdentifier());
+		for (int i = parentPath.size() - 1; i >= 0; i--) {
+			parentPrefLabelPath.add(thesaurusConceptService.getConceptTitle(parentPath.get(i)));
+		}
+		parentPrefLabelPath.add(thesaurusConceptService.getConceptTitle(thesaurusConcept));
+		doc.addField(SolrField.PARENT_CONCEPT, parentPrefLabelPath);
+		
 		String prefLabel;
 		try {
 			prefLabel = thesaurusConceptService.getConceptPreferredTerm(

--- a/ginco-impl/src/main/java/fr/mcc/ginco/solr/SearcherServiceImpl.java
+++ b/ginco-impl/src/main/java/fr/mcc/ginco/solr/SearcherServiceImpl.java
@@ -57,7 +57,7 @@ public class SearcherServiceImpl implements ISearcherService {
 	@Override
 	public SearchResultList search(String request, Integer type,
 	                               String thesaurus, Integer status, String createdFrom,
-	                               String modifiedFrom, String language, SortCriteria sort, int startIndex, int limit)
+	                               String modifiedFrom, String language, SortCriteria sort, int startIndex, int limit, String parent)
 			throws SolrServerException {
 
 		ModifiableSolrParams params = new ModifiableSolrParams();
@@ -77,6 +77,7 @@ public class SearcherServiceImpl implements ISearcherService {
 						+ searcherServiceUtil.addAndQuery(SolrField.THESAURUSID, thesaurus, null, true)
 						+ searcherServiceUtil.addAndQuery(SolrField.STATUS, status, null, false)
 						+ searcherServiceUtil.addAndQuery(SolrField.LANGUAGE, language, null, false)
+						+ searcherServiceUtil.addAndQuery(SolrField.PARENT_CONCEPT, parent, null, true)
 						+ searcherServiceUtil.getExtTypeQuery(type)
 		);
 

--- a/ginco-impl/src/main/java/fr/mcc/ginco/solr/SearcherServiceUtil.java
+++ b/ginco-impl/src/main/java/fr/mcc/ginco/solr/SearcherServiceUtil.java
@@ -34,18 +34,22 @@
  */
 package fr.mcc.ginco.solr;
 
-import fr.mcc.ginco.utils.DateUtil;
-import org.apache.solr.common.SolrDocument;
-import org.apache.solr.common.SolrDocumentList;
-import org.springframework.stereotype.Service;
-
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 
+import org.apache.solr.common.SolrDocument;
+import org.apache.solr.common.SolrDocumentList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import fr.mcc.ginco.utils.DateUtil;
+
 @Service
 public class SearcherServiceUtil {
-
+	private Logger logger = LoggerFactory.getLogger(SearcherServiceUtil.class);
 	private static final String CLOSE_PARENTHESIS = ")";
 	private static final String OPEN_PARENTHESIS = "(";
 	private static final String OR = " OR ";
@@ -152,6 +156,14 @@ public class SearcherServiceUtil {
 			languages.add(lang.toString());
 		}
 		result.setLanguages(languages);
+		List<String> broaders = new ArrayList<String>();
+		Collection<Object> values = doc.getFieldValues(SolrField.PARENT_CONCEPT);
+		if (values != null) {
+			for (Object broader : values) {
+				broaders.add(broader.toString());
+			}
+		}
+		result.setBroaders(broaders);
 		return result;
 	}
 

--- a/ginco-solr-conf/solr/thesaurus/conf/schema.xml
+++ b/ginco-solr-conf/solr/thesaurus/conf/schema.xml
@@ -17,6 +17,7 @@
                 <field name="notes" type="text_fr" indexed="true" stored="true" multiValued="true"/>
                 <field name="_version_" type="long" indexed="true" stored="true"/>
                 <field name="conceptId" type="string" indexed="false" stored="true" multiValued="false" />
+                <field name="parentConcept" type="string" indexed="true" stored="true" multiValued="true" />
             </fields>
 
             <uniqueKey>identifier</uniqueKey>

--- a/ginco-webservices/src/main/java/fr/mcc/ginco/soap/SOAPThesaurusTermServiceImpl.java
+++ b/ginco-webservices/src/main/java/fr/mcc/ginco/soap/SOAPThesaurusTermServiceImpl.java
@@ -181,7 +181,7 @@ public class SOAPThesaurusTermServiceImpl implements ISOAPThesaurusTermService {
 				}
 				SearchResultList searchResultList = searcherService.search(
 						requestFormat, searchType, thesaurusId, intStatus, null, null, null, crit,
-						startIndex, limit);
+						startIndex, limit, null);
 				if (searchResultList != null) {
 					for (SearchResult searchResult : searchResultList) {
 						ReducedThesaurusTerm reducedThesaurusTerm = new ReducedThesaurusTerm();


### PR DESCRIPTION
Modifications dans le cadre du projet agorha pour l'INHA

* Ajout prefLabelsPath dans api getConcept

* ajout filtre sur arborescence d'un thesaurus lors d'une recherche

* utilisation basic auth pour certains endpoints

* passage en mode basic authentification sur le service REST d'import de Thesaurus

* Correction de la gestion des caractères accentuées lors de l'import des fichiers au format SKOS, texte, Ginco

* Recupération des parents d'un concept dans les thésaurus

* correction nullpointer dans la recherche si concept sans parent

* correction Logger ImportRestService

Co-authored-by: DERIGENT David (Externe - sous-traitant SSL) <david.derigent@sword-group.com>
Co-authored-by: CORTINOVIS Jonathan <jonathan.cortinovis@sword-group.com>